### PR TITLE
fix: 通过鼠标点击在多个 el-tree-select 之间切换焦点时, el-tree-select 的下拉框无法消失.

### DIFF
--- a/src/components/src/ElTreeSelect.vue
+++ b/src/components/src/ElTreeSelect.vue
@@ -458,7 +458,7 @@ export default {
             const path = this._getEventPath(e);
             let isInside = path.some(list => {
                 // 鼠标在弹出框内部，阻止隐藏弹出框
-                return list.className && typeof list.className === 'string' && list.className.indexOf('el-tree-select') !== -1;
+                return list.id === `el-tree-select-${this.guid}`;
             });
             if (!isInside) {
                 this.visible = false;


### PR DESCRIPTION
PR for #94